### PR TITLE
Do not fail build if vergen fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+
+# IDE specific files
+/.idea

--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ use vergen::{vergen, Config, ShaKind};
 fn main() -> Result<()> {
   let out_dir = env::var("OUT_DIR")?;
   let dest_path = Path::new(&out_dir).join("sentry_api_key.txt");
-  let mut f = BufWriter::new(File::create(&dest_path)?);
+  let mut f = BufWriter::new(File::create(dest_path)?);
   // If we have an API key available, save it to a file so we can build it in. If not, leave it
   // blank.
   if let Ok(api_key) = env::var("SENTRY_API_KEY") {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -233,8 +233,8 @@ async fn main() -> Result<(), IntifaceEngineError> {
     println!(
       "Intiface CLI (Rust Edition) Version {}, Commit {}, Built {}",
       VERSION,
-      env!("VERGEN_GIT_SHA_SHORT"),
-      env!("VERGEN_BUILD_TIMESTAMP")
+      option_env!("VERGEN_GIT_SHA_SHORT").unwrap_or("unknown"),
+      option_env!("VERGEN_BUILD_TIMESTAMP").unwrap_or("unknown")
     );
     return Ok(());
   }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -12,10 +12,7 @@ use crate::{
 };
 use buttplug::{
   core::{
-    connector::{
-      ButtplugRemoteServerConnector,
-      ButtplugWebsocketServerTransportBuilder,
-    },
+    connector::{ButtplugRemoteServerConnector, ButtplugWebsocketServerTransportBuilder},
     message::serializer::ButtplugServerJSONSerializer,
   },
   server::{ButtplugRemoteServer, ButtplugServerBuilder, ButtplugServerConnectorError},


### PR DESCRIPTION
In the past, the build script was changed to allow `vergen` to fail. However, in the crate itself, `vergen` was still assumed to succeed, causing a build to fail if `vergen` fails.

The problem was using the `env!` macro with environment variables that fails if the environment variables do not exist. I replaced this with `option_env!(...).unwrap("unknown")`.

This pull request allows the crate to compile with a failing `vergen`.

Additional minor changes: added IntelliJ IDEA files to gitignore.
Additional minor fixes: lints & formatting